### PR TITLE
Typo in date of day 2? 23 instead of 12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Session 2 - 2 hours
 | 09    | SAR data access, NISAR and CGM | Tymofyeyeva |
 #### Breakout session continue with assigned groups
 
-#### DAY-2 – July 13
+#### DAY-2 – July 12
 Session 3 – 1.5 hours
 | **Number** | **Theme** | **Instructor** |
 |-----------|--------------|--------------|

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Session 2 - 2 hours
 | 09    | SAR data access, NISAR and CGM | Tymofyeyeva |
 #### Breakout session continue with assigned groups
 
-#### DAY-2 – July 23
+#### DAY-2 – July 13
 Session 3 – 1.5 hours
 | **Number** | **Theme** | **Instructor** |
 |-----------|--------------|--------------|


### PR DESCRIPTION
July 23 is a Saturday and in the Unavco page says 13. So I think it is typo.

PS: I change 13 to 12. 